### PR TITLE
fix(composables): Encode URL parameters in useHistory

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,41 @@
+# Code Review Guidelines
+
+## Scope
+
+In scope:
+
+- Component changes (`src/components/`, `src/composables/`)
+- TypeScript type definitions (`src/types/`)
+- Test changes (`tests/`)
+- Build configuration (`vite.config.ts`, `vitest.config.mts`)
+- CI/CD workflow changes
+- Renovate configuration updates
+
+Out of scope:
+
+- Auto-generated lock files (`package-lock.json`)
+- Build artifacts (`dist/`)
+- Coverage reports (`coverage/`)
+- Renovate dependency-only PRs (patch/minor with automerge enabled)
+
+## Required checks
+
+- All tests pass (`npm test`)
+- TypeScript type check passes (`npm run type-check`)
+- ESLint passes (`npm run lint`)
+- No secrets committed
+- New features include tests
+- Public API changes reflected in types (`src/types/index.d.ts`)
+
+## Severity levels
+
+| Level        | Meaning                                             | Merge impact       |
+| ------------ | --------------------------------------------------- | ------------------ |
+| Bug          | Incorrect behavior or broken contract               | Blocks merge       |
+| Nit          | Minor issue — suboptimal but not incorrect          | Non-blocking       |
+| Pre-existing | Issue present before this PR; flagged for awareness | No action required |
+
+## Skip
+
+- Renovate PRs with `automerge: true` (patch/minor) after CI passes
+- Documentation-only changes with no functional impact

--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -55,7 +55,10 @@ export function useHistory(city: AllowedCity) {
 
   const API_BASE = "https://aareguru.existenz.ch/v2018/history";
 
-  async function fetchHistory(start: HistoryRange | string = "yesterday", end: HistoryRange | "now" | string = "now"): Promise<void> {
+  async function fetchHistory(
+    start: HistoryRange | string = "yesterday",
+    end: HistoryRange | "now" | string = "now"
+  ): Promise<void> {
     isLoading.value = true;
     error.value = null;
 

--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -55,12 +55,12 @@ export function useHistory(city: AllowedCity) {
 
   const API_BASE = "https://aareguru.existenz.ch/v2018/history";
 
-  async function fetchHistory(start: string = "yesterday", end: string = "now"): Promise<void> {
+  async function fetchHistory(start: HistoryRange | string = "yesterday", end: HistoryRange | "now" | string = "now"): Promise<void> {
     isLoading.value = true;
     error.value = null;
 
     try {
-      const url = `${API_BASE}?city=${city}&start=${start}&end=${end}&app=vue.aareguru`;
+      const url = `${API_BASE}?city=${city}&start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}&app=vue.aareguru`;
       const response = await axios.get(url, { timeout: 10000 });
 
       if (response.data) {

--- a/src/composables/useHistory.ts
+++ b/src/composables/useHistory.ts
@@ -63,7 +63,7 @@ export function useHistory(city: AllowedCity) {
     error.value = null;
 
     try {
-      const url = `${API_BASE}?city=${city}&start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}&app=vue.aareguru`;
+      const url = `${API_BASE}?city=${encodeURIComponent(city)}&start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}&app=vue.aareguru`;
       const response = await axios.get(url, { timeout: 10000 });
 
       if (response.data) {


### PR DESCRIPTION
The `start` and `end` parameters in `useHistory.fetchHistory()` were
interpolated directly into the request URL without encoding. Any string
containing `&` or `=` would inject additional query parameters into the
Aareguru API request.

Use `encodeURIComponent()` on both parameters to neutralize special
characters while leaving all valid inputs unchanged — `HistoryRange`
shorthand values (`"yesterday"`, `"week"`, etc.), ISO date strings
(`"2026-01-01"`), and `"now"` are all URL-safe and encode to themselves.

The type signature is also narrowed to `HistoryRange | string` to hint
at the expected values without breaking callers that pass date strings.