### PR TITLE
release: v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ and [human-readable changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-03-22
+
+### Fixed
+
+- **Composables**: `useHistory` — `start`, `end`, and `city` parameters are now URL-encoded via
+  `encodeURIComponent`, preventing parameter injection for inputs containing special characters
+- **Security**: Resolved transitive dev-dependency vulnerabilities via `overrides`:
+  - `flatted` → `^3.4.2` (Prototype Pollution)
+  - `minimatch` → `^10.2.3` (ReDoS)
+  - `rollup` → `^4.59.0` (Arbitrary File Write via Path Traversal)
+
+### Changed
+
+- **Engines**: Updated Node.js requirement to `^20.19.0 || >=22.12.0` (aligns with Vite 8)
+- Updated development dependencies:
+  - vite: 7.x → 8.0.1
+  - vitest + @vitest/\*: 4.0.18 → 4.1.0
+  - storybook + @storybook/\*: 10.2.x → 10.3.1
+
 ## [2.3.0] - 2026-03-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue.aareguru",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vue.aareguru",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "devDependencies": {
         "@chromatic-com/storybook": "^5.0.1",
         "@storybook/addon-a11y": "^10.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue.aareguru",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "description": "Vue 3 component that displays the Aare river temperature from Aareguru API.",
   "main": "dist/vue.aareguru.cjs",


### PR DESCRIPTION
Patch release to correctly publish all fixes to npm that were merged after `v2.3.0` was already published (2026-02-21).

The `v2.3.0` npm package was published by an old CI run that subsequently failed at the "Verify publication" step. All subsequent PRs (#419–#422) landed on `main` after that publish, so npm never received them.

**What's new in this patch vs npm `v2.3.0`:**
- `fix`: `useHistory` URL encoding via `encodeURIComponent` (#420)
- `fix`: Dependabot security overrides for `flatted`, `minimatch`, `rollup` (#419)
- `chore`: Vite 8 / vitest 4.1.0 / Storybook 10.3.1 upgrade (#421)
- `chore`: `engines` aligned to `^20.19.0 || >=22.12.0` (#421)