### PR TITLE
ci: align workflows with sbaerlocher repo standard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>sbaerlocher/.github:renovate-js#2026-03-22"],
+  "extends": ["github>sbaerlocher/.github:renovate-js#2026-04-30"],
   "packageRules": [
     {
       "groupName": "Vue",

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -3,7 +3,7 @@ name: Claude Code Review
 
 "on":
   pull_request:
-    types: [opened, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/ai-claude-review.yml
+++ b/.github/workflows/ai-claude-review.yml
@@ -14,6 +14,6 @@ permissions:
 jobs:
   claude-review:
     name: Claude Code Review
-    uses: sbaerlocher/.github/.github/workflows/ai-claude-review.yml@2026-03-28
+    uses: sbaerlocher/.github/.github/workflows/ai-claude-review.yml@2026-04-30
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@
 name: Continuous Integration
 
 "on":
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
   workflow_call:
@@ -31,7 +29,7 @@ jobs:
             primary: false
           - node-version: "24.x"
             primary: false
-    uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-03-28
+    uses: sbaerlocher/.github/.github/workflows/ci-js.yml@2026-04-30
     with:
       package-manager: "npm"
       node-version: ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   release:
     name: NPM Package Release
-    uses: sbaerlocher/.github/.github/workflows/release-npm.yml@2026-03-28
+    uses: sbaerlocher/.github/.github/workflows/release-npm.yml@2026-04-30
     with:
       package-manager: "npm"
       node-version-file: ".nvmrc"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,12 +2,8 @@
 name: Security Scanning
 
 on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
   schedule:
-    - cron: "0 2 * * 1" # Weekly Monday 02:00 UTC
+    - cron: "0 6 * * 1" # Weekly Monday 06:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -19,18 +15,18 @@ permissions:
 jobs:
   code-analysis:
     name: SAST (CodeQL)
-    uses: sbaerlocher/.github/.github/workflows/security-code.yml@2026-03-28
+    uses: sbaerlocher/.github/.github/workflows/security-code.yml@2026-04-30
     with:
       languages: '["javascript-typescript"]'
       node-version-file: ".nvmrc"
 
   dependency-scan:
     name: Dependencies & Licenses
-    uses: sbaerlocher/.github/.github/workflows/security-deps.yml@2026-03-28
+    uses: sbaerlocher/.github/.github/workflows/security-deps.yml@2026-04-30
     with:
       language: "javascript"
       enable-license-check: true
 
   secret-detection:
     name: Secret Detection
-    uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@2026-03-28
+    uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@2026-04-30


### PR DESCRIPTION
## Summary

Align `.github/workflows/` and `.github/renovate.json` with the [Repo Standard sbaerlocher](https://github.com/sbaerlocher/.github) — focused on CI trigger convention, scheduled-workflow rules, and stale reusable-workflow date-tags.

### Changes per file

- **`ci.yml`** — drop `push: [main]` trigger. CI now runs on `pull_request` and via `workflow_call` only. Tag-push test execution is handled internally by `release-npm.yml` (`run-tests: true`). Avoids duplicate runs on main without losing test coverage.
- **`security.yml`** — `schedule` + `workflow_dispatch` only (drop `push` and `pull_request` triggers per Standard, which prevents the workflow from being eligible as a required status check). Cron bumped from `0 2 * * 1` to `0 6 * * 1` (Standard default 06:00 UTC). Dead `master` branch reference removed.
- **Reusable workflow date-tags** — bumped `@2026-03-28` → `@2026-04-30` across `ci-js`, `release-npm`, `security-code`, `security-deps`, `security-secrets`, `ai-claude-review`.
- **`renovate.json`** — bumped `renovate-js` preset ref `#2026-03-22` → `#2026-04-30`.

### Source

- [Repo Standard sbaerlocher (Vault)](https://github.com/sbaerlocher/.github) — sections "CI-Trigger-Konvention (No Duplicate Runs)", "Scheduled-Workflows", "Required Workflows pro Repo-Typ".

## Test plan

- [ ] CI runs on this PR (verifies `pull_request` trigger still fires)
- [ ] Verify Status Check `ci` (or `Continuous Integration / All Checks Passed`) is green across the Node matrix (20.x / 22.x / 24.x)
- [ ] After merge: confirm no double CI runs on main (only release.yml runs internal tests on tag push)
- [ ] Next Monday: verify `security.yml` schedule fires at 06:00 UTC