### PR TITLE
fix(ci): add concurrency-suffix to security workflows

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       languages: '["javascript-typescript"]'
       node-version-file: ".nvmrc"
+      concurrency-suffix: code
 
   dependency-scan:
     name: Dependencies & Licenses
@@ -26,7 +27,10 @@ jobs:
     with:
       language: "javascript"
       enable-license-check: true
+      concurrency-suffix: deps
 
   secret-detection:
     name: Secret Detection
     uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@2026-05-07
+    with:
+      concurrency-suffix: secrets

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   code-analysis:
     name: SAST (CodeQL)
-    uses: sbaerlocher/.github/.github/workflows/security-code.yml@2026-05-07
+    uses: sbaerlocher/.github/.github/workflows/security-code.yml@2026-06-08
     with:
       languages: '["javascript-typescript"]'
       node-version-file: ".nvmrc"
@@ -23,7 +23,7 @@ jobs:
 
   dependency-scan:
     name: Dependencies & Licenses
-    uses: sbaerlocher/.github/.github/workflows/security-deps.yml@2026-05-07
+    uses: sbaerlocher/.github/.github/workflows/security-deps.yml@2026-06-08
     with:
       language: "javascript"
       enable-license-check: true
@@ -31,6 +31,6 @@ jobs:
 
   secret-detection:
     name: Secret Detection
-    uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@2026-05-07
+    uses: sbaerlocher/.github/.github/workflows/security-secrets.yml@2026-06-08
     with:
       concurrency-suffix: secrets


### PR DESCRIPTION
## Summary

- **Root cause**: All three reusable security workflows (`security-code`, `security-deps`, `security-secrets`) use the same concurrency group `"Security Scanning"-<ref>` with `cancel-in-progress: true`. When called in parallel from the same parent workflow, they cancel each other — whichever starts last wins, the others are killed. This is why the weekly Security Scanning run has shown as `cancelled` every week since May.
- **Fix**: Pass distinct `concurrency-suffix` values (`code`, `deps`, `secrets`) to each job. This is the exact pattern already used correctly in `tsmetrics/security.yml`.

## Test plan

- [ ] Merge and manually trigger "Security Scanning" via `workflow_dispatch`
- [ ] Verify all three jobs run to completion instead of being cancelled