### PR TITLE
fix(renovate): lokale Vue/Vite-Gruppen-Overrides entfernen

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,14 +3,6 @@
   "extends": ["github>sbaerlocher/.github:renovate-js#2026-06-10"],
   "packageRules": [
     {
-      "groupName": "Vue",
-      "matchPackageNames": ["/^vue/", "/^@vue/"]
-    },
-    {
-      "groupName": "Vite",
-      "matchPackageNames": ["/^vite$/", "/^@vitejs/"]
-    },
-    {
       "description": "Official Vue testing library - stable, not truly abandoned",
       "matchPackageNames": ["@vue/test-utils"],
       "abandonmentThreshold": null


### PR DESCRIPTION
## Problem

Das lokale `.github/renovate.json` definierte eigene Gruppen `Vue` (`vue`, `@vue/*`) und `Vite` (`vite`, `@vitejs/*`). Renovate merged `packageRules` der Reihe nach, daher überschrieben diese lokalen Regeln die **peer-gekoppelten Gruppen des Org-Presets**:

- "Build tooling (Vite + Vitest)" — koppelt `vite` + `vitest` + `@vitest/*` (peerDependency)
- "Vue packages" — koppelt `vue` + `@vue/*` + `@vitejs/plugin-vue`

Durch den Override wurde `vite` von `vitest` und `vue` von `@vitejs/plugin-vue` getrennt.

## Auswirkung

Genau das hat die kaputten PRs #452 / #460 / #462 erzeugt: `@vitest/browser` wurde ohne `vitest` gebumpt (`peer vitest@x`-Konflikt), die Lockfiles ließen sich nicht regenerieren (`renovate/artifacts` Failure → `npm ci` rot in CI).

## Fix

Die Splitter-Regeln entfernen, damit die korrekt gekoppelten Preset-Gruppen wieder greifen — gekoppelte Pakete kommen so wieder in **einen** PR mit konsistentem Lockfile. Die `@vue/test-utils`-Override (`abandonmentThreshold`) bleibt erhalten.

## Validierung

- `renovate-config-validator` gegen Renovate 43.220.0: **Config validated successfully**
- pre-push-Hooks (typecheck + 51 Tests) grün