### PR TITLE
chore(repo): trim redundant CODEOWNERS, recommend VS Code extensions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Default owner
-* @sbaerlocher

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,9 @@ yarn-error.log*
 
 # Editor directories and files
 .idea
-.vscode
+# Allowlist shared VS Code config, ignore the rest
+.vscode/*
+!.vscode/extensions.json
 *.suo
 *.ntvs*
 *.njsproj

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "Vue.volar",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "vitest.explorer",
+    "EditorConfig.EditorConfig"
+  ]
+}


### PR DESCRIPTION
## Summary

- Remove `.github/CODEOWNERS` — it only duplicated the org-default (`sbaerlocher/.github`: `* @sbaerlocher`), which now applies.
- Add `.vscode/extensions.json` recommending the repo's actual stack (Volar, ESLint, Prettier, Vitest, EditorConfig).
- Switch the `.gitignore` `.vscode` blanket-ignore to an allowlist so the shared config is tracked.

## Test plan

- [ ] CI green
- [ ] org-default CODEOWNERS still assigns `@sbaerlocher` as reviewer