### PR TITLE
fix(deps): add .npmrc legacy-peer-deps to unblock lockfile updates

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,6 @@
+# legacy-peer-deps tolerates transient peer mismatches in the
+# vitest/storybook ecosystem. Without it, Renovate's lockfile regeneration
+# fails (renovate/artifacts) whenever a security update bumps one @vitest/*
+# package ahead of the rest, and CI `npm ci` then breaks on the stale lock.
+# Drop this once the vitest peer ranges stop churning.
+legacy-peer-deps=true


### PR DESCRIPTION
## Summary

- Renovate's lockfile regeneration (`renovate/artifacts`) fails whenever a security update bumps one `@vitest/*` package ahead of the rest of the vitest stack — npm's strict peer resolution rejects the transient mismatch, the lockfile stays stale, and CI `npm ci` then breaks.
- Add `.npmrc` with `legacy-peer-deps=true` so both Renovate's regen and CI install tolerate these transient peer mismatches. Unblocks the stuck dependency PRs (#471 `@vitest/browser` security, #473 vitest, #474 vue).
- Marked for removal once the vitest peer ranges stop churning.

## Test plan

- [ ] CI green (`npm ci` + tests + CodeQL)
- [ ] After merge: re-run Renovate → #471/#473/#474 regenerate green, then merge