### PR TITLE
ci(pull-request): cancel superseded runs on new PR pushes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,6 +16,10 @@ permissions:
   actions: read
   id-token: write
 
+concurrency:
+  group: pull-request-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: Quality, Tests, Build


### PR DESCRIPTION
## Summary

- Add a top-level `concurrency:` block to `pull-request.yml` keyed on `github.ref` with `cancel-in-progress: true`, so a new push to a PR cancels its in-flight run instead of stacking a second full run.
- Saves runner minutes and shortens feedback cycles on superseded pushes.
- `tag.yml` intentionally keeps `cancel-in-progress: false` for releases.

## Test plan

- [ ] CI green on this PR
- [ ] Push a follow-up commit and confirm the prior run is cancelled