### PR TITLE
style(prettier): ignore pnpm-lock.yaml in format check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,4 +4,5 @@ coverage/
 node_modules/
 *.d.ts
 package-lock.json
+pnpm-lock.yaml
 storybook-static/


### PR DESCRIPTION
## Summary

- Add `pnpm-lock.yaml` to `.prettierignore`. The npm-to-pnpm migration ignored `package-lock.json` but not the pnpm lockfile, so `prettier --check` flags the generated file and fails `Test & Lint` on every Renovate PR that regenerates it.
- Lockfiles are generated output and should never be format-checked.

## Test plan

- [ ] `pnpm format:check` green locally
- [ ] CI green on this PR
- [ ] Open Renovate PRs go green after rebase onto this
