### PR TITLE
refactor(hooks): install lefthook via install-hooks.mjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "validate": "pnpm format:check && pnpm typecheck && pnpm lint && pnpm test",
     "clean": "rm -rf dist coverage node_modules/.vite",
     "clean:all": "pnpm clean && rm -rf node_modules pnpm-lock.yaml",
-    "prepare": "test ! -e .git || ! command -v git >/dev/null 2>&1 || lefthook install",
+    "prepare": "node scripts/install-hooks.mjs",
     "prepublishOnly": "pnpm typecheck && pnpm test:coverage",
     "storybook": "pnpm dev",
     "build:storybook": "storybook build"

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -11,8 +11,17 @@
 // both inside a pnpm lifecycle (where PATH is set) and when invoked
 // directly by a developer.
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
+
+// No git repo — nothing to wire up (e.g. a source tree copied without git
+// history in a Docker build). `lefthook install` needs `.git/hooks` and would
+// exit non-zero otherwise, breaking the install. `.git` is a file in worktrees
+// and submodules, so existsSync covers both.
+if (!existsSync(".git")) {
+  process.exit(0);
+}
 
 const require = createRequire(import.meta.url);
 

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+// Git hook installer — runs via the `prepare` lifecycle after install.
+//
+// Skips cleanly when lefthook isn't on disk (e.g. `pnpm install --prod` in
+// CI/Docker, where devDependencies aren't materialized) so the missing dev
+// dep doesn't break production installs. Real failures from `lefthook
+// install` itself are propagated as a non-zero exit so they can't hide.
+//
+// The bin path is resolved from lefthook's own package.json rather than
+// relying on `node_modules/.bin` being in PATH — that way the script works
+// both inside a pnpm lifecycle (where PATH is set) and when invoked
+// directly by a developer.
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+
+let pkgPath;
+let pkg;
+try {
+  pkgPath = require.resolve("lefthook/package.json");
+  pkg = require("lefthook/package.json");
+} catch {
+  // lefthook not installed — nothing to wire up, succeed silently.
+  process.exit(0);
+}
+
+const binField = typeof pkg.bin === "string" ? pkg.bin : pkg.bin?.lefthook;
+if (!binField) {
+  console.error("[install-hooks] lefthook package.json has no `bin.lefthook` entry");
+  process.exit(1);
+}
+
+const lefthookBin = resolve(dirname(pkgPath), binField);
+const result = spawnSync(process.execPath, [lefthookBin, "install"], {
+  stdio: "inherit",
+  shell: false
+});
+if (result.error) {
+  console.error(`[install-hooks] failed to spawn lefthook: ${result.error.message}`);
+  process.exit(1);
+}
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary

- Replace the inline-shell `prepare` script with `node scripts/install-hooks.mjs`, aligning this repo with the Fleet lefthook-bootstrap canon (Option B).
- The installer resolves the lefthook bin from its own `package.json` rather than relying on `node_modules/.bin` being on PATH, and skips cleanly when lefthook isn't installed (production installs) instead of failing.

## Test plan

- [x] `node scripts/install-hooks.mjs` syncs pre-commit + pre-push hooks
- [x] Skips cleanly (exit 0) when lefthook is absent
- [ ] CI green