### PR TITLE
chore(renovate): hold typescript below v7

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,11 @@
       "description": "Official Vue testing library - stable, not truly abandoned",
       "matchPackageNames": ["@vue/test-utils"],
       "abandonmentThreshold": null
+    },
+    {
+      "description": "vue-tsc CLI requires typescript/lib/tsc, which TS 7 no longer exports (vuejs/language-tools#5381). Drop this rule once a vue-tsc release supports TS 7.",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add a Renovate `packageRule` capping `typescript` at `<7`, so no further TS major update PRs are opened while they cannot pass CI.
- The `vue-tsc` CLI resolves `typescript/lib/tsc`, a subpath TS 7 removed from its exports map, which fails every typecheck step with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Upstream tracking issue: vuejs/language-tools#5381.
- The rule carries a description noting it should be dropped once a `vue-tsc` release supports TS 7.

## Test plan

- [ ] `.github/renovate.json` parses as valid JSON and matches the Renovate schema
- [ ] `pnpm typecheck` passes on the pinned TS 6 toolchain
- [ ] CI green