### PR TITLE
chore(repo): add CODEOWNERS with global owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sbaerlocher


### PR DESCRIPTION
## Summary

- Add `.github/CODEOWNERS` assigning `* @sbaerlocher` as global owner
- Aligns the repo with the org standard; several active sbaerlocher repos lacked this file

## Test plan

- [ ] CI green